### PR TITLE
Bugfix/duplicate keys

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -156,7 +156,6 @@
         </div>
       
         <div class="page-content">
-      
           <div class="list no-hairlines-md">
       
             <script id="tpl-translations" type="text/template7">
@@ -319,7 +318,6 @@
 
       <!-- search-options -->
       <div class="popup popup-search-options">
-
         <div class="page-content">
 
           <div class="block-title">Search In</div>
@@ -371,13 +369,11 @@
           </div>
 
         </div>
-
       </div>
       <!-- end: search-options -->
 
       <!-- filter-options -->
       <div class="popup popup-filter-options">
-
         <div class="page-content">
 
           <div class="block-title">Show Labels</div>
@@ -401,17 +397,24 @@
                   </div>
                 </label>
               </li>
+              <li>
+                <label class="item-radio item-content">
+                  <input type="radio" name="filter_labels" value="onlydups" />
+                  <i class="icon icon-radio"></i>
+                  <div class="item-inner">
+                    <div class="item-title">Duplicate labels only</div>
+                  </div>
+                </label>
+              </li>
             </ul>
           </div>
 
         </div>
-
       </div>
       <!-- end: filter-options -->
 
       <!-- new-options -->
       <div class="popup popup-new-options">
-      
         <div class="page-content">
       
           <div class="block-title">Create New File or Locale</div>
@@ -439,13 +442,35 @@
           </div>
       
         </div>
-      
       </div>
       <!-- end: new-options -->
 
+      <!-- duplicates -->
+      <div class="popup popup-duplicates">
+        <div class="page-content">
+
+          <div class="block-title">Duplicate Labels</div>
+          <div class="card">
+            <div class="card-content card-content-padding">Make sure you resolve the duplicate label translations before saving your bundles. Use the filter to show only duplicates.</div>
+          </div>
+          <div class="list simple-list">
+            <ul id="duplicate-labels">
+              <!-- tpl-duplicate-labels -->
+            </ul>
+          </div>
+
+          <script id="tpl-duplicate-labels" type="text/template7">
+          {{#each duplicates}}
+          <li>{{@key}}</li>
+          {{/each}}
+          </script>
+
+        </div>
+      </div>
+      <!-- end: duplicates -->
+
       <!-- about -->
       <div class="popup popup-about">
-
         <div class="page-content">
 
           <div class="block-title">About Reside</div>
@@ -464,8 +489,8 @@
           <div class="display-flex justify-content-center">
              Avatar icon (Residé, the cat) by&nbsp;<a href="#" class="about-link-icon">Iconka.com</a>
           </div>
-        </div>
 
+        </div>
       </div>
       <!-- end: about -->
 

--- a/src/resloader/resloader.js
+++ b/src/resloader/resloader.js
@@ -82,16 +82,18 @@ class ResLoader {
   _loadFiles(files) {
     return new Promise((resolve, reject) => {
       const index = {};
+      const duplicates = {};
 
       const promised = files.map((entry) => new ResBundle(
-        path.join(this._path, entry.file), entry.file, entry.locale).reload(index));
+        path.join(this._path, entry.file), entry.file, entry.locale).reload(
+          index, duplicates));
 
       Promise.all(promised).then((loadedBundles) => {
         const bundles = new Map();
         for (const bundle of loadedBundles) {
           bundles.set(bundle.filename, bundle);
         }
-        resolve({ index, bundles });
+        resolve({ bundles, index, duplicates });
       }).catch((e) => {
         console.error(`Error loading bundle file!`, e);
         reject(e);

--- a/test/data/TestDuplicates_de.properties
+++ b/test/data/TestDuplicates_de.properties
@@ -1,0 +1,6 @@
+DialogName=Nachricht Dialog
+ButtonSave=Speichern
+ButtonLoad=Laden
+ButtonClear=Löschen
+DialogName=Text-Nachricht Dialog
+ButtonClear=Zurücksetzen

--- a/test/data/TestDuplicates_en.properties
+++ b/test/data/TestDuplicates_en.properties
@@ -1,0 +1,7 @@
+DialogName=Message Dialog
+ButtonSave=Save
+ButtonLoad=Load
+ButtonClear=Clear
+DialogName=Text Message Dialog
+ButtonClear=Reset
+DialogName=Text Dialog English

--- a/test/test_resloader.js
+++ b/test/test_resloader.js
@@ -95,6 +95,23 @@ describe('resloader', () => {
           assert.equal(bundles.get(name).get('Message_Categories2'), 'Reisen\\Hotels');
         });
     });
+
+    it('should load duplicate translations - TestDuplicates', () => {
+      return new ResLoader()
+        .path(`${__dirname}/data`)
+        .name('TestDuplicates')
+        .load().then((result) => {
+          const { index, bundles, duplicates } = result;
+          assert.notEqual(index, null);
+          assert.notEqual(index, {});
+          assert.notEqual(duplicates, null);
+          assert.notEqual(duplicates, {});
+          assert.equal(bundles.size, 2);
+          assert.ok('ButtonClear_DUP1' in duplicates);
+          assert.ok('DialogName_DUP1' in duplicates);
+          assert.ok('DialogName_DUP2' in duplicates);
+        });
+    });
   });
 
   describe('#rename()', () => {


### PR DESCRIPTION
Show duplicate labels dialog on bundles load. A filter for duplicates is also added, so that users may easily find and resolve duplicate translations.